### PR TITLE
Interdimentional Warp Bin

### DIFF
--- a/mods/dpr_main/scripts/main/warp_bin.lua
+++ b/mods/dpr_main/scripts/main/warp_bin.lua
@@ -17,6 +17,7 @@
 ---@field flagvalue? any the value that the flag in flagcheck should be equal to
 ---@field on_fail? fun(cutscene: WorldCutscene) called when the condition is not satifised
 ---@field silence_system_messages? boolean
+---@field mod? string the mod ID of a mod to swap into.
 
 ---@class WarpBinCodeInfoMini
 ---@field result string map id


### PR DESCRIPTION
Allows warp bins to (conveniently) point to other mods.

Here's an example of how it can be used:

```lua
-- warp_bin.lua
Mod.warp_bin_codes = {
    ...,
    ["KRISYARD"] = { result = "light/hometown/krisyard", mod = "dpr_light"},
}
```