### PR TITLE
Fix the CI

### DIFF
--- a/build.py
+++ b/build.py
@@ -134,7 +134,6 @@ ignorefiles = [
     ".github",
     ".git",
     ".vscode",
-    "mods",
     "docs",
     "lib",
     "build"

--- a/build.py
+++ b/build.py
@@ -261,20 +261,6 @@ for file in os.listdir(os.path.join(kristal_path, "lib")):
 print("Zipping built file...")
 shutil.make_archive(os.path.join(output_path, "kristal-"+ver_str+"-win"), 'zip', os.path.join(build_path, "executable"))
 
-print("Packaging example mod...")
-
-try:
-    os.makedirs(os.path.join(build_path, "example"))
-except FileExistsError:
-    pass
-
-shutil.copytree(os.path.join(kristal_path, "mod_template", "assets"), os.path.join(build_path, "example", "assets"))
-shutil.copytree(os.path.join(kristal_path, "mod_template", "scripts"), os.path.join(build_path, "example", "scripts"))
-shutil.copy(os.path.join(kristal_path, "mods", "example", "mod.json"), os.path.join(build_path, "example", "mod.json"))
-shutil.copy(os.path.join(kristal_path, "mod_template", "mod.lua"), os.path.join(build_path, "example", "mod.lua"))
-
-shutil.make_archive(os.path.join(output_path, "example-mod"), 'zip', os.path.join(build_path, "example"))
-
 print("Done!")
 print("Generated files:")
 print("> kristal-"+ver_str+".love")


### PR DESCRIPTION
Builds a .love, and windows portable. This makes it much easier to get DPR set up.

Someone with management permissions will need to enable Actions in [the Actions tab](https://github.com/darkplace-dr/DarkPlaceRebirth-Kristal/actions) for this to do anything.