### PR TITLE
Add movement_table to LoadingDarkTransition

### DIFF
--- a/mods/dpr_light/scripts/world/cutscenes/enterdark.lua
+++ b/mods/dpr_light/scripts/world/cutscenes/enterdark.lua
@@ -24,7 +24,14 @@ function enterdark.shelter(cutscene)
     cutscene:panTo(620, 2240, 0.25)
     cutscene:wait(0.25)
     
-    local transition = LoadingDarkTransition(-500)
+    local transition = LoadingDarkTransition(-500, {
+        movement_table = ({
+            {  0.00 },
+            {  0.50, -0.50 },
+            {  0.50, -0.50,  0.00 },
+            {  1.00,  0.00, -1.00,  0.00 }
+        })[#party]
+    })
     transition.loading_callback = function() 
         -- Game.world:loadMap("light/hometown/apartments")
         DTRANS = true


### PR DESCRIPTION
This makes it more in-line with the `darkenter` cutscene.
The vertical positioning is still off, though. Ideally, we persist the character_data through the transition and use that for the `darkenter` cutscene.