### PR TITLE
Optionally skip warning on second startup.

### DIFF
--- a/src/engine/menu/mainmenu.lua
+++ b/src/engine/menu/mainmenu.lua
@@ -118,6 +118,8 @@ function MainMenu:enter()
 
     if #Kristal.Mods.failed_mods > 0 then
         self:setState("MODERROR")
+    elseif Kristal.Config["seenLegitWarning"] and Kristal.Config["skipIntro"] then
+        self:setState("TITLE")
     else
         self:setState("WARNING")
     end


### PR DESCRIPTION
The initial legit warning ignores the skipIntro setting. This only really means anything with old settings files.