### PR TITLE
Scan DLCs for basic bin code data

### DIFF
--- a/mods/dpr_main/scripts/main/warp_bin.lua
+++ b/mods/dpr_main/scripts/main/warp_bin.lua
@@ -59,6 +59,18 @@ Mod.warp_bin_codes["GREYAREA"] = gray_area_info
 ---@return WarpBinCodeInfo info
 function Mod:getBinCode(code)
     code = code:upper()
+    for id, mod in  pairs(Kristal.Mods.data) do
+        if mod.dlc and mod.dlc.extraBinCodes and mod.dlc.extraBinCodes[code] then
+            local info = mod.dlc.extraBinCodes[code]
+            if info == true then
+                return {
+                    result = mod.map,
+                    mod = id,
+                }
+            end
+            return info
+        end
+    end
 
     return Mod.warp_bin_codes[code]
 end


### PR DESCRIPTION
This parses the `extraBinCodes` format seen in the test dlc's [mod.json](<https://github.com/polypoyo/dlc_test/blob/8d166299d353b12bdd62228c1ca5d3d4072b36dd/mod.json#L70-L74>).