### PR TITLE
Bosses data parsing

### DIFF
--- a/src/engine/game/battle.lua
+++ b/src/engine/game/battle.lua
@@ -2388,6 +2388,22 @@ function Battle:returnToWorld()
     self.encounter.defeated_enemies = self.defeated_enemies
     Game.battle = nil
     Game.state = "OVERWORLD"
+    if Game.bossrush_encounters then
+        table.remove(Game.bossrush_encounters, 1)
+        if #Game.bossrush_encounters > 0 then
+            local boss = Game:getBossRef(Game.bossrush_encounters[1])
+            if boss.mod == Mod.info.id then
+                Game:encounter(boss.encounter)
+            else
+                Kristal.swapIntoMod(boss.mod)
+            end
+        else
+            Game.bossrush_encounters = nil
+            -- Can't use Game:swapIntoMod because it kicks you
+            -- back to the title screen before that happens
+            Kristal.swapIntoMod("dpr_main", false, "main_hub")
+        end
+    end
 end
 
 function Battle:setActText(text, dont_finish)

--- a/src/engine/game/game.lua
+++ b/src/engine/game/game.lua
@@ -1233,13 +1233,14 @@ end
 
 ---@param ignore_light? boolean -- if you still want some stats etc. despite being in LW
 function Game:getBadgeStorage(ignore_light)
-    if Game:isLight() and not ignore_light then return {} end
+    if self:isLight() and not ignore_light then return {} end
     local inventory ---@type DarkInventory
-    if not Game:isLight() then
-        inventory = Game.inventory
+    if not self:isLight() then
+        inventory = self.inventory
     else
-        inventory = Game.inventory:getItemByID("light/ball_of_junk").inventory
+        inventory = self.dark_inventory
     end
+    if not inventory then return {} end
     return inventory:getStorage("badges")
 end
 


### PR DESCRIPTION
Completely untested with multi-DLC because mine is the only DLC that has bosses data :/

To use:
```
-- set up the boss rush using the IDs set in the mod.json
Game.bossrush_encounters = {"dummy", "bigdummy"} 
-- manually swap to the mod of the first encounter
Game:swapIntoMod(Game:getBossRef(Game.bossrush_encounters[1]).mod) 
```