### PR TITLE
Try to load https module from source directory

### DIFF
--- a/src/lib/discordrpc.lua
+++ b/src/lib/discordrpc.lua
@@ -8,6 +8,16 @@ end
 
 local ok, discordRPClib = pcall(ffi.load, name)
 
+-- Apparently, that doesn't work for some reason like it did for the https module.
+-- It's fine since Discord RPC isn't critical for Rebirth but it's a bit weird
+if not discordRPClib then
+    ok, discordRPClib = pcall(ffi.load, "lib/"..name)
+end
+
+if not discordRPClib then
+    ok, discordRPClib = pcall(ffi.load, love.filesystem.getSource().."/lib/"..name)
+end
+
 DISCORD_RPC_AVAILABLE = ok
 
 if not ok then

--- a/src/lib/https.lua
+++ b/src/lib/https.lua
@@ -14,12 +14,17 @@ if not module then
 end
 
 if not module then
+    ok, module = pcall(package.loadlib, love.filesystem.getSource().."/lib/"..name, "luaopen_https")
+end
+
+if not module then
     ok = false
 end
 
 HTTPS_AVAILABLE = ok
 
 if not ok then
+    print("The HTTPS library has failed to load.")
     return
 end
 


### PR DESCRIPTION
If Kristal can't load the HTTPS module from LOVE's directory, it will try to directly load it from itself (the `lib/` folder)

If this works, that should prevent many people from asking why the DLC handler doesn't