### PR TITLE
Banned Key list updated

### DIFF
--- a/configs/extra.json
+++ b/configs/extra.json
@@ -10,7 +10,8 @@
         "Console": "console",
         "Debug Menu": "debug_menu",
         "Object Selector": "object_selector",
-        "Fast Forward": "fast_forward"
+        "Fast Forward": "fast_forward",
+        "Mod Rebind": "mod_rebind"
     },
 
     // Menu Scroller


### PR DESCRIPTION
Added "mod_rebind" to the list of ban key in order for it to not show up in the game rebind menu.