### PR TITLE
PluginLoader support

### DIFF
--- a/mods/dpr_main/preview/preview.lua
+++ b/mods/dpr_main/preview/preview.lua
@@ -53,6 +53,7 @@ function preview:update()
     local is_options = (MainMenu.state == "OPTIONS")
         or (MainMenu.state == "DEFAULTNAME")
         or (MainMenu.state == "CONTROLS")
+        or (Utils.startsWith(MainMenu.state, "plugin"))
     if is_options and self.music_once == 0 then
 
         self.music_settings = Music("options_starry")

--- a/src/engine/menu/mainmenuoptions.lua
+++ b/src/engine/menu/mainmenuoptions.lua
@@ -82,6 +82,7 @@ end
 -------------------------------------------------------------------------------
 
 function MainMenuOptions:onEnter(old_state)
+    if old_state == "plugins" then return end
     self.selected_option = 1
     self.selected_page = 1
 
@@ -658,6 +659,23 @@ function MainMenuOptions:initializeOptions()
 
     self:registerConfigOption("gameplay", "Prefer Goner Keybd.", "prefersGonerKeyboard")
     self:registerConfigOption("gameplay", "Enable Shatter", "enableShatter")
+    self:registerOption("gameplay", "Plugins", function ()
+        ---@diagnostic disable-next-line: undefined-field
+        if Kristal.PluginLoader == nil then return "N/A" end
+        local active, total = 0, 0
+        local enabled = Kristal.Config["plugins/enabled_plugins"] or {}
+        for _, mod in ipairs(Kristal.Mods.getMods()) do
+            if mod.plugin then total = total + 1 end
+            if enabled[mod.id] then active = active + 1 end
+        end
+        return active.."/"..total
+    end,
+    function ()
+        ---@diagnostic disable-next-line: undefined-field
+        if Kristal.PluginLoader == nil then Assets.playSound("ui_cant_select"); return end
+        self:remove_noel_char()
+        self.menu:setState("plugins")
+    end)
 end
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Note that previous versions of PluginLoader prevent DPR from loading it's custom registry types, so you'll need to be on a the latest version (`2e79ed6` as of this PR)