### PR TITLE
Made __concat metafunction more robust I think??

### DIFF
--- a/src/engine/tweaks.lua
+++ b/src/engine/tweaks.lua
@@ -28,17 +28,33 @@ end
 -- "string" .. Sprite()
 string_metatable.__concat = function (a, b)
     -- Do not allow nil to be concatenated
-    if type(b) == "nil" then
-        return a..""
+    if type(a) == "nil" or type(b) == "nil" then
+        return error("attempt to concatenate a nil value")
     end
 
+    -- Handle the a value
+    -- If it's a class, concatenate its name
+    if isClass(a) then
+        a = Utils.getClassName(a)
+    -- If it's a table, dump it
+    elseif type(a) == "table" then
+        a = Utils.dump(a)
+    -- If all fails, just convert it to a string
+    else
+        a = tostring(a)
+    end
+
+    -- Handle the b value
     -- If it's a class, concatenate its name
     if isClass(b) then
-        return a..Utils.getClassName(b)
+        b = Utils.getClassName(b)
     -- If it's a table, dump it
     elseif type(b) == "table" then
-        return a..Utils.dump(b)
+        b = Utils.dump(b)
+    -- If all fails, just convert it to a string
+    else
+        b = tostring(b)
     end
-    -- Just convert it to a string
-    return a..tostring(b)
+
+    return a..b
 end


### PR DESCRIPTION
So I might be stupid and thought for some reason that the `a` value would be always fine or something?
Anyway now the function (metafunction?) manually raise the "attempt to concatenate a nil value" error is either `a` or `b` is nil and `a` is also changed as needed the same way `b` is changed
That should prevent some concatenation problems that nobody ever had except Charbomber