### PR TITLE
Actually use the length of the vararg for console print

### DIFF
--- a/src/engine/game/console.lua
+++ b/src/engine/game/console.lua
@@ -44,16 +44,16 @@ function Console:createEnv()
     end
 
     function env.print(...)
-        local arg = {...}
+        local arg = {n = select("#", ...), ...}
         local print_string = ""
 
-        for i = 1, math.max(1,table.maxn(arg)) do
+        for i = 1, arg.n do
             local str = arg[i]
             if type(str) == "table" then
                 str = Utils.dump(str)
             end
             print_string = print_string .. tostring(str)
-            if i ~= table.maxn(arg) then
+            if i ~= arg.n then
                 print_string = print_string  .. "    "
             end
         end


### PR DESCRIPTION
Makes it behave exactly* like base lua's print.

*aside from the indentation between arguments