### PR TITLE
Don't load MGR if we don't need it

### DIFF
--- a/mods/dpr_light/mod.json
+++ b/mods/dpr_light/mod.json
@@ -36,8 +36,7 @@
     "setWindowTitleAndIcon": null,
 
     "sharedlibs": [
-        "mg2party",
-        "magical-glass-2"
+        "magical-glass"
     ],
     // Config values for the engine and any libraries you may have.
     // These config values can control chapter-specific features as well.

--- a/sharedlibs/dp/lib.lua
+++ b/sharedlibs/dp/lib.lua
@@ -10,4 +10,16 @@ function lib:onPause()
     end
 end
 
+function lib:save(data)
+    if not MagicalGlassLib then
+        data.magical_glass = self.mg_data_preserve
+    end
+end
+
+function lib:load(data)
+    if not MagicalGlassLib then
+        self.mg_data_preserve = data.magical_glass
+    end
+end
+
 return lib

--- a/sharedlibs/magical-glass-redux/lib.json
+++ b/sharedlibs/magical-glass-redux/lib.json
@@ -10,8 +10,6 @@
 
     "version": "v2.25.23",
     "engineVer": "v0.10.0-dev",
-    
-    "default": true, // Dark Place Rebirth
 
     "config": {
         


### PR DESCRIPTION
In theory, this would break a DLC that doesn't declare it's dependency of MGR for some reason. Pretty sure nobody's doing that though, so it's fine.