### PR TITLE
DarkConfigMenu - Rebind menu pages

### DIFF
--- a/configs/extra.json
+++ b/configs/extra.json
@@ -2,9 +2,19 @@
     //Extra Binding Pages Menu - Config
     "saveAfterModification": false,     //Save keybinds when modifying them.
     "cancelToExit": false,              //Allow you to press the cancel key to get out of the binding menu.
+    "onlyMyDLCBind": false,               //Make it so no other bind beside the default DarkPlace one and the DLC one are loaded.
     "hideIfNoExtra": true,              //Hide the page counter and the arrows when there is no extra keybind.
     "showArrow": true,                  //Show arrows next to the page counter if conditions are met.
+    "bannedKeys": {                     //List of key to hide in the binding menu. (Contains an example)
+        //"Name_of_key": "id_of_key"
+        "Console":          "console",
+        "Debug Menu":       "debug_menu",
+        "Object Selector":  "object_selector",
+        "Fast Forward":     "fast_forward",
+        "Mod Rebind":       "mod_rebind"
+    },
 
     // Menu Scroller
-    "darkMenuScroller": "middle"               //Wether the scroller is centered based around the center or two points (string: middle||side)
+    "darkMenuScroller": "middle",       //Wether the scroller is centered based around the center or two points (string: middle||side)
+    
 }

--- a/src/engine/game/world/ui/dark/darkconfigmenu.lua
+++ b/src/engine/game/world/ui/dark/darkconfigmenu.lua
@@ -43,35 +43,65 @@ function DarkConfigMenu:init()
         {"simple",  "Simple",  "simple"},
         {"none",    "None",    nil}
     }
+    self.keybinds = {}
+    
+    self:registerKeybind()
+
+    self.control_page = 1
+    self.max_control_page = math.ceil(#self.keybinds/7)
 end
 
-function DarkConfigMenu:getBindNumberFromIndex(current_index)
-    local shown_bind = 1
-    local alias = Input.orderedNumberToKey(current_index)
-    local keys = Input.getBoundKeys(alias, Input.usingGamepad())
-    for index, current_key in ipairs(keys) do
-        if Input.usingGamepad() then
-            if Utils.startsWith(current_key, "gamepad:") then
-                shown_bind = index
-                break
-            end
-        else
-            if not Utils.startsWith(current_key, "gamepad:") then
-                shown_bind = index
-                break
-            end
+function DarkConfigMenu:registerKeybind()
+    local alr_used = {}
+
+    for _, keybind in ipairs(Input.order) do
+        if not (Utils.containsValue(Game:getConfig("bannedKeys"), keybind) or Utils.containsValue(alr_used, keybind)) then
+            table.insert(self.keybinds, {keybind = keybind, name = (Input.getBindName(keybind) or keybind:gsub("_", " ")):upper()})
+            table.insert(alr_used, keybind)
         end
     end
-    return shown_bind
+
+    if not Game:getConfig("onlyMyDLCBind") then
+        for mod_id, keys in pairs(Input.mod_keybinds) do
+            local mod = Kristal.Mods.getMod(mod_id)
+            if mod["hideKeybinds"] then
+                goto continue
+            end
+
+            for _, keybind in ipairs(keys) do
+                if not (Utils.containsValue(Game:getConfig("bannedKeys"), keybind) or Utils.containsValue(alr_used, keybind)) then
+                    table.insert(self.keybinds, {keybind = keybind, name = (Input.getBindName(keybind) or keybind:gsub("_", " ")):upper()})
+                    table.insert(alr_used, keybind)
+                end
+            end
+
+            ::continue::
+        end
+    else
+        local mod_id , keys = Mod.info.id, Input.mod_keybinds[Mod.info.id]
+        local mod = Kristal.Mods.getMod(mod_id)
+        if mod["hideKeybinds"] then
+            goto continue
+        end
+
+        for _, keybind in ipairs(keys) do
+            if not (Utils.containsValue(Game:getConfig("bannedKeys"), keybind) or Utils.containsValue(alr_used, keybind)) then
+                table.insert(self.keybinds, {keybind = keybind, name = (Input.getBindName(keybind) or keybind:gsub("_", " ")):upper()})
+                table.insert(alr_used, keybind)
+            end
+        end
+        ::continue::
+    end
 end
 
 function DarkConfigMenu:onKeyPressed(key)
     if self.state == "CONTROLS" then
         if self.rebinding then
             local gamepad = Utils.startsWith(key, "gamepad:")
+            local key_rebind = self.keybinds[self.currently_selected + ((self.control_page - 1) * 7)]["keybind"]
 
             local worked = key ~= "escape" and
-                Input.setBind(Input.orderedNumberToKey(self.currently_selected), 1, key, gamepad)
+                Input.setBind(key_rebind, 1, key, gamepad)
 
             self.rebinding = false
 
@@ -123,9 +153,15 @@ function DarkConfigMenu:onKeyPressed(key)
         local old_selected = self.currently_selected
         if Input.pressed("up") then
             self.currently_selected = self.currently_selected - 1
+            if (self.currently_selected > 1 and self.currently_selected <= 7) and not self.keybinds[self.currently_selected + 8*(self.control_page - 1)] then
+                self.currently_selected = #self.keybinds - 7*(self.control_page - 1)
+            end
         end
         if Input.pressed("down") then
             self.currently_selected = self.currently_selected + 1
+            if self.currently_selected < 8 and not self.keybinds[self.currently_selected + 7*(self.control_page - 1)] then
+                self.currently_selected = 8
+            end
         end
 
         self.currently_selected = Utils.clamp(self.currently_selected, 1, 9)
@@ -133,6 +169,29 @@ function DarkConfigMenu:onKeyPressed(key)
         if old_selected ~= self.currently_selected then
             self.ui_move:stop()
             self.ui_move:play()
+        end
+
+        local old_page = self.control_page
+        if Input.pressed("left") then
+            self.control_page = self.control_page - 1
+        end
+        if Input.pressed("right") then
+            self.control_page = self.control_page + 1
+        end
+
+        self.control_page = Utils.clamp(self.control_page, 1, self.max_control_page)
+
+        if old_page ~= self.control_page then
+            self.ui_move:stop()
+            self.ui_move:play()
+
+            if not self.keybinds[self.currently_selected + 7*(self.control_page - 1)] and self.currently_selected <= 7 then
+                if self.currently_selected <= (#self.keybinds - 7*self.control_page)/2 + 7 then
+                    self.currently_selected = #self.keybinds - 7*(self.control_page - 1)
+                else
+                    self.currently_selected = 8
+                end
+            end
         end
     end
 end
@@ -246,6 +305,8 @@ function DarkConfigMenu:update()
                 self.currently_selected = 2
                 Input.clear("confirm", true)
             end
+        else
+            return
         end
     elseif self.state == "BORDER" then
         if Input.pressed("cancel") or Input.pressed("confirm") then
@@ -304,12 +365,7 @@ function DarkConfigMenu:draw()
         end
 		
     --  Code for the arrow sprite
-        local sine_off
-        if sine_off == nil then
-            sine_off = 0
-        end
-
-        sine_off = math.sin((Kristal.getTime()*30)/16) * 3
+        local sine_off = math.sin((Kristal.getTime()*30)/16) * 3
 
         if Game:getConfig("showArrow") and self.max_config_pages > 1 then
             if self.current_config_page ~= 1 then
@@ -371,55 +427,56 @@ function DarkConfigMenu:draw()
             love.graphics.print(Kristal.isConsole() and "Button" or "Gamepad", 353, -12)
         end
 
-        for index, name in ipairs(Input.order) do
-            if index > 7 then
-                break
-            end
-            Draw.setColor(PALETTE["world_text"])
-            if self.currently_selected == index then
-                if self.rebinding then
-                    Draw.setColor(PALETTE["world_text_rebind"])
-                else
-                    Draw.setColor(PALETTE["world_text_hover"])
-                end
-            end
-
-            if dualshock then
-                love.graphics.print(name:gsub("_", " "):upper(), 23, -4 + (29 * index))
-            else
-                love.graphics.print(name:gsub("_", " "):upper(), 23, -4 + (28 * index) + 4)
-            end
-
-            local shown_bind = self:getBindNumberFromIndex(index)
-
-            if not Kristal.isConsole() then
-                local alias = Input.getBoundKeys(name, false)[1]
-                if type(alias) == "table" then
-                    local title_cased = {}
-                    for _, word in ipairs(alias) do
-                        table.insert(title_cased, Utils.titleCase(word))
-                    end
-                    love.graphics.print(table.concat(title_cased, "+"), 243, 0 + (28 * index))
-                elseif alias ~= nil then
-                    love.graphics.print(Utils.titleCase(alias), 243, 0 + (28 * index))
-                end
-            end
-
-            Draw.setColor(1, 1, 1)
-
-            if Input.hasGamepad() then
-                local alias = Input.getBoundKeys(name, true)[1]
-                if alias then
-                    local btn_tex = Input.getButtonTexture(alias)
-                    if dualshock then
-                        Draw.draw(btn_tex, 353 + 42, -2 + (29 * index), 0, 2, 2, btn_tex:getWidth() / 2, 0)
+        Draw.pushScissor()
+        Draw.scissor(15, 30, 440, 200)
+        for index, key_info in ipairs(self.keybinds) do
+            if not (index < ((self.control_page - 1) * 7) - 1 or index > (self.control_page * 7)) then
+                Draw.setColor(PALETTE["world_text"])
+                local offset = ((self.control_page - 1) * 7)
+                if self.currently_selected == index - offset then
+                    if self.rebinding then
+                        Draw.setColor(PALETTE["world_text_rebind"])
                     else
-                        Draw.draw(btn_tex, 353 + 42 + 16 - 6, -2 + (28 * index) + 11 - 6 + 1, 0, 2, 2,
-                                btn_tex:getWidth() / 2, 0)
+                        Draw.setColor(PALETTE["world_text_hover"])
+                    end
+                end
+
+                if dualshock then
+                    love.graphics.print(key_info.keybind:gsub("_", " "):upper(), 23, -4 + (29 * (index - offset)))
+                else
+                    love.graphics.print(key_info.keybind:gsub("_", " "):upper(), 23, -4 + (28 * (index - offset)) + 4)
+                end
+                
+                if not Kristal.isConsole() then
+                    local alias = Input.getBoundKeys(key_info.keybind, false)[1]
+                    if type(alias) == "table" then
+                        local title_cased = {}
+                        for _, word in ipairs(alias) do
+                            table.insert(title_cased, Utils.titleCase(word))
+                        end
+                        love.graphics.print(table.concat(title_cased, "+"), 243, 0 + (28 * (index - offset)))
+                    elseif alias ~= nil then
+                        love.graphics.print(Utils.titleCase(alias), 243, 0 + (28 * (index - offset)))
+                    end
+                end
+
+                Draw.setColor(1, 1, 1)
+
+                if Input.hasGamepad() then
+                    local alias = Input.getBoundKeys(key_info.keybind, true)[1]
+                    if alias then
+                        local btn_tex = Input.getButtonTexture(alias)
+                        if dualshock then
+                            Draw.draw(btn_tex, 353 + 42, -2 + (29 * (index - offset)), 0, 2, 2, btn_tex:getWidth() / 2, 0)
+                        else
+                            Draw.draw(btn_tex, 353 + 42 + 16 - 6, -2 + (28 * (index - offset)) + 11 - 6 + 1, 0, 2, 2,
+                                    btn_tex:getWidth() / 2, 0)
+                        end
                     end
                 end
             end
         end
+        Draw.popScissor()
 
         Draw.setColor(PALETTE["world_text"])
         if self.currently_selected == 8 then
@@ -454,6 +511,24 @@ function DarkConfigMenu:draw()
             Draw.draw(self.heart_sprite, -2, 34 + ((self.currently_selected - 1) * 29))
         else
             Draw.draw(self.heart_sprite, -2, 34 + ((self.currently_selected - 1) * 28) + 2)
+        end
+
+
+        Draw.setColor(COLORS.white)
+        local page_offset = ((self.max_control_page >= 10 and self.control_page >= 10) and 14) or ((self.max_control_page >= 10 and self.control_page < 10) and 6) or 0
+        if self.max_control_page > 1 then
+            love.graphics.print(self.control_page.."/"..self.max_control_page, 418 - page_offset, -4 + (28 * 9) + 4)
+        end
+
+        local sine_off = math.sin((Kristal.getTime()*30)/16) * 3
+
+        if Game:getConfig("showArrow") and self.max_control_page > 1 then
+            if self.control_page ~= 1 then
+                Draw.draw(self.flat_arrow_sprite, 410 - page_offset + sine_off, 264, 0, -1, 1)
+            end
+            if self.control_page ~= self.max_control_page then
+                Draw.draw(self.flat_arrow_sprite, 466 + page_offset - sine_off, 264)
+            end
         end
     end
 


### PR DESCRIPTION
Remade the rebind pages system thing in a more optimized way.

Added `"onlyMyDLCBind"` config which allow people to  only show keybinds in their DLC or by default in DarkPlace.
ReAdded `"bannedKeys"` config.

Removed the `getBindNumberFromIndex()` function from the DarkConfigMenu since it's now unused. I'll put it back if necessary.