### PR TITLE
Option to reload DLC list first time you open it

### DIFF
--- a/src/engine/menu/mainmenudlchandler.lua
+++ b/src/engine/menu/mainmenudlchandler.lua
@@ -89,8 +89,17 @@ function MainMenuDLCHandler:onEnter()
 	--self.menu.heart_target_y = -16
 
 	if not self.list then
+		if (Kristal.Config["ardlc"] and Kristal.loadedDLCs ~= true) then
+		
+		end
 		print("Build the DLC list")
 		self:buildDLCList()
+		if (Kristal.Config["ardlc"] and Kristal.loadedDLCs ~= true) then
+			self:reloadMods(function()
+				self:buildDLCList(true)
+			end)
+			Kristal.loadedDLCs = true
+		end
 	else
 		self.list.active = true
 		self.list.visible = true

--- a/src/engine/menu/mainmenuoptions.lua
+++ b/src/engine/menu/mainmenuoptions.lua
@@ -267,7 +267,7 @@ function MainMenuOptions:draw()
         Draw.popScissor()
     end
 
-    Draw.printShadow("Back", menu_x, 408 - 8, 2, "left", 640)
+    Draw.printShadow("Back", menu_x, 440 - 8, 2, "left", 640)
 
     self.state_manager:draw()
 end
@@ -534,7 +534,7 @@ function MainMenuOptions:getHeartPos()
     else
         -- "Back" button
         x = 27
-        y = 480 - 64 + 3
+        y = 512 - 64 + 3
     end
 
     return x + self.heart_x, y
@@ -648,6 +648,8 @@ function MainMenuOptions:initializeOptions()
                         end)
 
     self:registerConfigOption({ "general", "graphics" }, "Simplify VFX", "simplifyVFX")
+	
+    self:registerConfigOption("general", "Auto-Reload DLC", "ardlc")
 
     self:registerOption("graphics", "Target FPS", function (x, y)
                             if Kristal.Config["fps"] > 0 then

--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -1676,6 +1676,7 @@ function Kristal.loadConfig()
         debug = true,
         fullscreen = false,
         simplifyVFX = false,
+		ardlc = false,
         autoRun = false,
         masterVolume = 0.6,
         favorites = {},


### PR DESCRIPTION
It's been something that annoyed me; I defaulted it to not happening, you can change it in the options