### PR TITLE
Fix Utils.absoluteToLocalPath returning nil when the file is in a lib

### DIFF
--- a/src/utils/utils.lua
+++ b/src/utils/utils.lua
@@ -1754,10 +1754,19 @@ function Utils.absoluteToLocalPath(prefix, image, path)
     -- Split paths by seperator
     local base_path = Utils.split(path, "/")
     local dest_path = Utils.split(image, "/")
-    while dest_path[1] == ".." do
-        -- Move up one directory
-        table.remove(base_path, #base_path)
-        table.remove(dest_path, 1)
+    do
+        local up_count = 0
+        while dest_path[1] == ".." do
+            up_count = up_count + 1
+            -- Move up one directory
+            table.remove(base_path, #base_path)
+            table.remove(dest_path, 1)
+        end
+        if dest_path[1] == "libraries" then
+            for i = 2, up_count do
+                table.remove(dest_path, 1)
+            end
+        end
     end
 
     local final_path = table.concat(Utils.merge(base_path, dest_path), "/")


### PR DESCRIPTION
As branch name implies, this allows using library tilesets in mod maps.