### PR TITLE
Added "swapped_dlc" argument to load callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ open.bat
 # Ignore aseprite files
 *.ase
 *.aseprite
+
+# desktop.ini files
+*.ini

--- a/src/engine/game/debugsystem.lua
+++ b/src/engine/game/debugsystem.lua
@@ -1182,6 +1182,11 @@ function DebugSystem:onKeyPressed(key, is_repeat)
             end
             return
         end
+        if key == "pageup" then
+            self.faces_y = self.faces_y + 512
+        elseif key == "pagedown" then
+            self.faces_y = self.faces_y - 512
+        end
     elseif self.state == "FLAGS" then
         if not Game.flags then
             self:setState("MENU")

--- a/src/engine/game/game.lua
+++ b/src/engine/game/game.lua
@@ -575,6 +575,8 @@ function Game:load(data, index, fade)
             end
         end
     end
+
+    local swapped_dlc = Game:getFlag("is_swapping_mods", false)
     -- Make sure it only comes back when you load a file, not when switching between DLCs
     if not Game:getFlag("is_swapping_mods", false) and Game:getFlag("oddstone_tossed", false) then
         -- If you threw away the Odd Stone, bring it back
@@ -588,7 +590,7 @@ function Game:load(data, index, fade)
     Game:setFlag("is_swapping_mods", false)
     -- END SAVE FILE VARIABLES --
 
-    Kristal.callEvent(KRISTAL_EVENT.load, data, self.is_new_file, index)
+    Kristal.callEvent(KRISTAL_EVENT.load, data, self.is_new_file, index, swapped_dlc)
 
     -- Load the map if we have one
     if map then
@@ -615,7 +617,7 @@ function Game:load(data, index, fade)
         self:encounter(self:getBossRef(self.bossrush_encounters[1]).encounter)
     end
 
-    Kristal.callEvent(KRISTAL_EVENT.postLoad)
+    Kristal.callEvent(KRISTAL_EVENT.postLoad, swapped_dlc)
 
 
     --Code stolen from Simbel's depths dlc


### PR DESCRIPTION
`load` and `postLoad` now have a new argument that is true if the mod was loaded due to DLC swapping. False if it was loaded from a save, debugging or whatever. Used in the Depths DLC

Also made it so using the PageUp and PageDown keys will make the Portrait Menu in the Debug Menu moves MUCH faster. Very useful when writing dialogue between **H**ero and **S**usie