### PR TITLE
"Nothing" Light Weapon and Armor

### DIFF
--- a/data/items/light/armors/_nothing.lua
+++ b/data/items/light/armors/_nothing.lua
@@ -1,0 +1,26 @@
+local item, super = Class(LightEquipItem, "light/_nothing_armor")
+
+function item:init()
+    super.init(self)
+
+    self.name = "Nothing"
+    self.short_name = "Nothing"
+
+    self.type = "armor"
+    self.light = true
+
+    self.price = nil
+    self.can_sell = false
+
+    self.description = "The lack of an armor."
+
+    self.check = "* But you don't have anything to check."
+
+    self.usable_in = "none"
+end
+
+function item:showEquipText()
+    Game.world:showText("* Somehow, you equipped "..self:getName()..".")
+end
+
+return item

--- a/data/items/light/weapons/_nothing.lua
+++ b/data/items/light/weapons/_nothing.lua
@@ -1,0 +1,26 @@
+local item, super = Class(LightEquipItem, "light/_nothing_armor")
+
+function item:init()
+    super.init(self)
+
+    self.name = "Nothing"
+    self.short_name = "Nothing"
+
+    self.type = "weapon"
+    self.light = true
+
+    self.price = nil
+    self.can_sell = false
+
+    self.description = "The lack of a weapon."
+
+    self.check = "* But you don't have anything to check."
+
+    self.usable_in = "none"
+end
+
+function item:showEquipText()
+    Game.world:showText("* Somehow, you equipped "..self:getName()..".")
+end
+
+return item

--- a/src/engine/game/common/data/partymember.lua
+++ b/src/engine/game/common/data/partymember.lua
@@ -875,10 +875,10 @@ function PartyMember:convertToLight()
     end
 
     if not self.equipped.weapon then
-        self.equipped.weapon = Registry.createItem(self.lw_weapon_default)
+        self.equipped.weapon = Registry.createItem(self.lw_weapon_default or "light/_nothing_weapon")
     end
     if not self.equipped.armor[1] then
-        self.equipped.armor[1] = Registry.createItem(self.lw_armor_default)
+        self.equipped.armor[1] = Registry.createItem(self.lw_armor_default or "light/_nothing_armor")
     end
 
     self.equipped.weapon.dark_item = last_weapon


### PR DESCRIPTION
Prevents a crash during item conversion if Magical Glass isn't there to handle it by giving party members with no default lw equipment a "Nothing" armor/weapon