### PR TITLE
"dlc" property for objects

### DIFF
--- a/mods/dpr_light/scripts/world/maps/light/hometown/town_graveyard/data.lua
+++ b/mods/dpr_light/scripts/world/maps/light/hometown/town_graveyard/data.lua
@@ -525,7 +525,7 @@ return {
           visible = true,
           properties = {
             ["actor"] = "brenda_lw",
-            ["cond"] = "Game:hasDLC(\"dlc_forest\")",
+            ["dlc"] = "dlc_forest",
             ["cutscene"] = "hometown.brenda",
             ["facing"] = "left"
           }

--- a/mods/dpr_light/scripts/world/maps/light/hometown/town_graveyard/town_graveyard.tmx
+++ b/mods/dpr_light/scripts/world/maps/light/hometown/town_graveyard/town_graveyard.tmx
@@ -159,7 +159,7 @@
   <object id="21" name="npc" x="80" y="350">
    <properties>
     <property name="actor" value="brenda_lw"/>
-    <property name="cond" value="Game:hasDLC(&quot;dlc_forest&quot;)"/>
+    <property name="dlc" value="dlc_forest"/>
     <property name="cutscene" value="hometown.brenda"/>
     <property name="facing" value="left"/>
    </properties>

--- a/mods/dpr_main/scripts/world/maps/main_outdoors/tower_outskirts_2/data.lua
+++ b/mods/dpr_main/scripts/world/maps/main_outdoors/tower_outskirts_2/data.lua
@@ -447,7 +447,7 @@ return {
           gid = 539,
           visible = true,
           properties = {
-            ["cond"] = "Game:hasDLC(\"dlc_trials\")"
+            ["dlc"] = "dlc_trials"
           }
         },
         {
@@ -462,7 +462,8 @@ return {
           rotation = 0,
           visible = true,
           properties = {
-            ["cond"] = "Game:hasDLC(\"dlc_trials\") and Game:hasPartyMember(\"hero\") and Game:hasPartyMember(\"susie\") and Game:hasPartyMember(\"noel\")",
+            ["dlc"] = "dlc_trials",
+            ["cond"] = "Game:hasPartyMember(\"hero\") and Game:hasPartyMember(\"susie\") and Game:hasPartyMember(\"noel\")",
             ["cutscene"] = "thevoid.altar1",
             ["solid"] = true
           }
@@ -479,7 +480,8 @@ return {
           rotation = 0,
           visible = true,
           properties = {
-            ["cond"] = "Game:hasDLC(\"dlc_trials\") and (not Game:hasPartyMember(\"hero\") or not Game:hasPartyMember(\"susie\") or not Game:hasPartyMember(\"noel\"))",
+            ["dlc"] = "dlc_trials",
+            ["cond"] = "(not Game:hasPartyMember(\"hero\") or not Game:hasPartyMember(\"susie\") or not Game:hasPartyMember(\"noel\"))",
             ["cutscene"] = "thevoid.altar1",
             ["solid"] = true
           }
@@ -607,7 +609,8 @@ return {
           gid = 542,
           visible = true,
           properties = {
-            ["cond"] = "Game:hasDLC(\"dlc_trials\") and Game:hasPartyMember(\"hero\") and Game:hasPartyMember(\"susie\") and Game:hasPartyMember(\"noel\")"
+            ["dlc"] = "dlc_trials",
+            ["cond"] = "Game:hasPartyMember(\"hero\") and Game:hasPartyMember(\"susie\") and Game:hasPartyMember(\"noel\")"
           }
         }
       }

--- a/mods/dpr_main/scripts/world/maps/main_outdoors/tower_outskirts_2/tower_outskirts_2.tmx
+++ b/mods/dpr_main/scripts/world/maps/main_outdoors/tower_outskirts_2/tower_outskirts_2.tmx
@@ -136,19 +136,21 @@
   </object>
   <object id="70" name="light_stand" gid="539" x="960" y="400" width="41" height="49">
    <properties>
-    <property name="cond" value="Game:hasDLC(&quot;dlc_trials&quot;)"/>
+    <property name="dlc" value="dlc_trials"/>
    </properties>
   </object>
   <object id="73" name="interactable" x="960" y="360" width="40" height="40">
    <properties>
-    <property name="cond" value="Game:hasDLC(&quot;dlc_trials&quot;) and Game:hasPartyMember(&quot;hero&quot;) and Game:hasPartyMember(&quot;susie&quot;) and Game:hasPartyMember(&quot;noel&quot;)"/>
+    <property name="dlc" value="dlc_trials"/>
+    <property name="cond" value="Game:hasPartyMember(&quot;hero&quot;) and Game:hasPartyMember(&quot;susie&quot;) and Game:hasPartyMember(&quot;noel&quot;)"/>
     <property name="cutscene" value="thevoid.altar1"/>
     <property name="solid" type="bool" value="true"/>
    </properties>
   </object>
   <object id="77" name="interactable" x="960" y="360" width="40" height="40">
    <properties>
-    <property name="cond" value="Game:hasDLC(&quot;dlc_trials&quot;) and (not Game:hasPartyMember(&quot;hero&quot;) or not Game:hasPartyMember(&quot;susie&quot;) or not Game:hasPartyMember(&quot;noel&quot;))"/>
+    <property name="dlc" value="dlc_trials"/>
+    <property name="cond" value="(not Game:hasPartyMember(&quot;hero&quot;) or not Game:hasPartyMember(&quot;susie&quot;) or not Game:hasPartyMember(&quot;noel&quot;))"/>
     <property name="cutscene" value="thevoid.altar1"/>
     <property name="solid" type="bool" value="true"/>
    </properties>
@@ -177,7 +179,8 @@
  <objectgroup color="#ff55ff" id="10" name="objects_back">
   <object id="67" gid="542" x="965" y="356.5" width="32" height="32">
    <properties>
-    <property name="cond" value="Game:hasDLC(&quot;dlc_trials&quot;) and Game:hasPartyMember(&quot;hero&quot;) and Game:hasPartyMember(&quot;susie&quot;) and Game:hasPartyMember(&quot;noel&quot;)"/>
+    <property name="dlc" value="dlc_trials"/>
+    <property name="cond" value="Game:hasPartyMember(&quot;hero&quot;) and Game:hasPartyMember(&quot;susie&quot;) and Game:hasPartyMember(&quot;noel&quot;)"/>
    </properties>
   </object>
  </objectgroup>

--- a/src/engine/game/world/map.lua
+++ b/src/engine/game/world/map.lua
@@ -641,6 +641,22 @@ function Map:loadObjects(layer, depth, layer_type)
                 else
                     skip_loading = not inverted
                 end
+            elseif v.properties["dlc"] then
+                local dlc_list = Utils.splitFast(v.properties["dlc"], ";")
+                for i,dlc_id in ipairs(dlc_list) do
+                    local inverted, id = Utils.startsWith(dlc_id:gsub(" ", ""), "!")
+
+                    result = Game:hasDLC(id)
+
+                    if inverted then
+                        result = not result
+                    end
+
+                    if not result then
+                        skip_loading = true
+                        break
+                    end
+                end
             end
 
             if not skip_loading then


### PR DESCRIPTION
idk I just felt like it made sense to have this property instead of using `cond`
Supports inversion with `!` for some reason and you can require multiple DLCs to be loaded (or not) by separating each ID with a `;`