### PR TITLE
Added a recheck to make sure the DLC still exists

### DIFF
--- a/src/engine/game/game.lua
+++ b/src/engine/game/game.lua
@@ -1488,15 +1488,8 @@ end
 ---@param dlc string -- the DLC ID to check for
 ---@param recheck bool -- to make sure if the DLC is actually still in the directory
 function Game:hasDLC(dlc, recheck)
-	-- Step 1. The original check with slight recoding.
-	-- Gotta make sure it's registered in the system.
-	local has_dlc = false
-    local dlcs = Utils.filter(Kristal.Mods.getMods(), function(mod) return not mod.hidden end)
-    for i, v in ipairs(dlcs) do
-        if v.id == dlc then
-            has_dlc = true
-        end
-    end
+	-- Step 1. Make sure it's registered in the system.
+	local has_dlc = (Kristal.Mods.getMod(dlc) ~= nil)
 	if has_dlc then
 		if (recheck ~= false) then
 			-- Step 2. Check to see if the directory actually still exists.


### PR DESCRIPTION
Happens by default, but you can make the second parameter of the function be `false` to make the game not recheck if you have the DLC.