### PR TITLE
Fix hookScript's super.super skipping the direct parent class of the target

### DIFF
--- a/src/utils/utils.lua
+++ b/src/utils/utils.lua
@@ -374,7 +374,7 @@ function Utils.hookScript(include)
         end
         include = r
     end
-    local super = {super = include.__super and include.__super.super or nil}
+    local super = {super = include.__super}
     local class = setmetatable({__hookscript_super = super, __hookscript_class = include}, Utils.HOOKSCRIPT_MT)
     return class, super
 end


### PR DESCRIPTION
I misunderstood how __super works.