### PR TITLE
PREVMAP system

### DIFF
--- a/sharedlibs/dp/scripts/hooks/World.lua
+++ b/sharedlibs/dp/scripts/hooks/World.lua
@@ -57,4 +57,11 @@ function World:shouldMb(map)
     return chance
 end
 
+function World:loadMap(...)
+    if self.map and self.map.id then
+        Game:setFlag("PREVMAP", self.map.id)
+    end
+    super.loadMap(self, ...)
+end
+
 return World


### PR DESCRIPTION
Should be used for loading maps. Lets you know what map you just came from so you can set up events. Persists through sessions.