### PR TITLE
Fixed the vents working only once on unlimited FPS

### DIFF
--- a/mods/dpr_main/scripts/world/events/ventlauncher.lua
+++ b/mods/dpr_main/scripts/world/events/ventlauncher.lua
@@ -155,7 +155,9 @@ function VentLauncher:update()
     end
 
 
-    if self.cooldown > 0 then self.cooldown = self.cooldown - 1 * DTMULT end
+    if self.cooldown > 0 then
+        self.cooldown = math.max(self.cooldown - 1 * DTMULT, 0)
+    end
 
 
 


### PR DESCRIPTION
Turns out `self.cooldown` would go into the negatives and the if condition that starts the cutscene wants `self.cooldown` to only be 0
So now `self.cooldown` can't go into the negatives anymore