### PR TITLE
Fixed VoidGlass not appearing

### DIFF
--- a/mods/dpr_main/scripts/world/maps/grey_cliffside/dead_room1/data.lua
+++ b/mods/dpr_main/scripts/world/maps/grey_cliffside/dead_room1/data.lua
@@ -1,7 +1,7 @@
 return {
   version = "1.10",
   luaversion = "5.1",
-  tiledversion = "1.11.0",
+  tiledversion = "1.10.0",
   class = "",
   orientation = "orthogonal",
   renderorder = "right-down",
@@ -10,7 +10,7 @@ return {
   tilewidth = 40,
   tileheight = 40,
   nextlayerid = 12,
-  nextobjectid = 72,
+  nextobjectid = 77,
   properties = {
     ["music"] = "demonic_little_grey_cliffs"
   },
@@ -52,48 +52,6 @@ return {
           y = 560,
           width = 40,
           height = 40,
-          rotation = 0,
-          visible = true,
-          properties = {}
-        }
-      }
-    },
-    {
-      type = "objectgroup",
-      draworder = "topdown",
-      id = 6,
-      name = "objects_glass",
-      class = "",
-      visible = true,
-      opacity = 1,
-      offsetx = 0,
-      offsety = 0,
-      parallaxx = 1,
-      parallaxy = 1,
-      properties = {},
-      objects = {
-        {
-          id = 29,
-          name = "voidglass",
-          type = "",
-          shape = "rectangle",
-          x = 80,
-          y = 540,
-          width = 160,
-          height = 40,
-          rotation = 0,
-          visible = true,
-          properties = {}
-        },
-        {
-          id = 61,
-          name = "magicglass",
-          type = "",
-          shape = "rectangle",
-          x = 560,
-          y = 200,
-          width = 240,
-          height = 120,
           rotation = 0,
           visible = true,
           properties = {}
@@ -186,6 +144,63 @@ return {
         14, 14, 14, 7, 14, 14, 14, 14, 14, 14, 14, 14, 14, 8, 15, 32, 32, 32, 33, 0,
         7, 14, 8, 17, 16, 14, 17, 14, 14, 14, 8, 7, 14, 16, 15, 41, 41, 41, 42, 0,
         23, 23, 23, 23, 23, 23, 26, 14, 25, 23, 23, 23, 23, 23, 24, 50, 50, 50, 51, 0
+      }
+    },
+    {
+      type = "objectgroup",
+      draworder = "topdown",
+      id = 6,
+      name = "objects_glass",
+      class = "",
+      visible = true,
+      opacity = 1,
+      offsetx = 0,
+      offsety = 0,
+      parallaxx = 1,
+      parallaxy = 1,
+      properties = {},
+      objects = {
+        {
+          id = 29,
+          name = "voidglass",
+          type = "",
+          shape = "rectangle",
+          x = 120,
+          y = 540,
+          width = 120,
+          height = 40,
+          rotation = 0,
+          visible = true,
+          properties = {}
+        },
+        {
+          id = 61,
+          name = "magicglass",
+          type = "",
+          shape = "rectangle",
+          x = 560,
+          y = 200,
+          width = 240,
+          height = 120,
+          rotation = 0,
+          visible = true,
+          properties = {}
+        },
+        {
+          id = 76,
+          name = "voidglass",
+          type = "",
+          shape = "rectangle",
+          x = 80,
+          y = 540,
+          width = 40,
+          height = 40,
+          rotation = 0,
+          visible = true,
+          properties = {
+            ["broken"] = true
+          }
+        }
       }
     },
     {
@@ -409,7 +424,7 @@ return {
           name = "",
           type = "",
           shape = "rectangle",
-          x = 40,
+          x = 50,
           y = 540,
           width = 40,
           height = 40,

--- a/mods/dpr_main/scripts/world/maps/grey_cliffside/dead_room1/dead_room1.tmx
+++ b/mods/dpr_main/scripts/world/maps/grey_cliffside/dead_room1/dead_room1.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="20" height="24" tilewidth="40" tileheight="40" infinite="0" nextlayerid="12" nextobjectid="72">
+<map version="1.10" tiledversion="1.10.0" orientation="orthogonal" renderorder="right-down" width="20" height="24" tilewidth="40" tileheight="40" infinite="0" nextlayerid="12" nextobjectid="77">
  <editorsettings>
   <export target="data.lua" format="lua"/>
  </editorsettings>
@@ -10,10 +10,6 @@
  <tileset firstgid="64" source="../../../tilesets/cliffs_objs.tsx"/>
  <objectgroup id="5" name="objects_bg">
   <object id="28" name="glitch_bg" x="520" y="560" width="40" height="40"/>
- </objectgroup>
- <objectgroup id="6" name="objects_glass">
-  <object id="29" name="voidglass" x="80" y="540" width="160" height="40"/>
-  <object id="61" name="magicglass" x="560" y="200" width="240" height="120"/>
  </objectgroup>
  <layer id="8" name="Tile Layer 2" width="20" height="24">
   <data encoding="csv">
@@ -71,6 +67,15 @@
 23,23,23,23,23,23,26,14,25,23,23,23,23,23,24,50,50,50,51,0
 </data>
  </layer>
+ <objectgroup id="6" name="objects_glass">
+  <object id="29" name="voidglass" x="120" y="540" width="120" height="40"/>
+  <object id="61" name="magicglass" x="560" y="200" width="240" height="120"/>
+  <object id="76" name="voidglass" x="80" y="540" width="40" height="40">
+   <properties>
+    <property name="broken" type="bool" value="true"/>
+   </properties>
+  </object>
+ </objectgroup>
  <objectgroup id="11" name="objects_crystal">
   <object id="49" name="neocrystal" x="244" y="70" width="112" height="160">
    <properties>
@@ -94,7 +99,7 @@
   <object id="23" x="80" y="500" width="120" height="40"/>
   <object id="24" x="80" y="580" width="120" height="40"/>
   <object id="26" x="360" y="456" width="40" height="224"/>
-  <object id="46" x="40" y="540" width="40" height="40"/>
+  <object id="46" x="50" y="540" width="40" height="40"/>
   <object id="56" x="480" y="120" width="80" height="40"/>
   <object id="58" x="160" y="720" width="80" height="40"/>
   <object id="59" x="80" y="360" width="80" height="16"/>

--- a/sharedlibs/dp/lib.lua
+++ b/sharedlibs/dp/lib.lua
@@ -554,9 +554,8 @@ end
 ---@param name string
 ---@param data table
 function lib:loadObject(world, name, data)
-    if false then
-    elseif name:lower() == "voidglass" then
-        return VoidGlass(data.x, data.y, rect_data, data.properties["broken"])
+    if name:lower() == "voidglass" then
+        return VoidGlass(data.x, data.y, {data.width, data.height, data.polygon}, data.properties["broken"])
     elseif name:lower() == "warpbin" then
         return WarpBin(data)
     elseif name:lower() == "superstar" then


### PR DESCRIPTION
- `rect_data` isn't defined in lib:loadObject() so it had to be changed to `{data.width, data.height, data.polygon}`
- `objects_glass` was below every tile layers??
- Someone fused all voidglass events into one event which removed the broken one at the end

_How did all of that happen?_
_(Also why was there a line that literally says `if false then`??)_