### PR TITLE
Fix crash with cutscene:taggedText() if the actor has no character

### DIFF
--- a/sharedlibs/dp/scripts/hooks/WorldCutscene.lua
+++ b/sharedlibs/dp/scripts/hooks/WorldCutscene.lua
@@ -40,7 +40,7 @@ function WorldCutscene:startMinigame(game)
     return self:wait(waitForGame)
 end
 
-
+-- This thing needs to be exploded
 --- Wrapper for [WorldCutscene:text](lua://WorldCutscene.text) that adds a nametag
 ---@overload fun(self: WorldCutscene, text: string, options?: table) : (finished:(fun():boolean), textbox: Textbox?)
 ---@overload fun(self: WorldCutscene, text: string, portrait?: string, options?: table) : (finished:(fun():boolean), textbox: Textbox?)
@@ -76,7 +76,11 @@ function WorldCutscene:textTagged(text, portrait, actor, options)
     if actor == nil then
         actor = self.textbox_actor
     end
-    self:showNametag(options.nametag or actor:getName(), {font = options.nametag_font or (actor and actor:getFont())})
+
+    if options.nametag or actor then
+        local tag = options.nametag or (type(actor) == "string" and Utils.titleCase(actor) or actor:getName())
+        self:showNametag(tag, {font = options.nametag_font or ((actor and isClass(actor)) and actor:getFont())})
+    end
     self:text(text, portrait, actor, options)
     self:hideNametag()
 end


### PR DESCRIPTION
If the function found no Character using the provided actor id, it would keep the id as is which means the function would try to call `getName()` on a string to set the nametag
This fixes the crash by using the id itself as the nametag. Not the best but whatever