### PR TITLE
Made Ceroba's voice blip accurate to UTY

### DIFF
--- a/data/actors/ceroba.lua
+++ b/data/actors/ceroba.lua
@@ -152,4 +152,9 @@ function actor:onWorldDraw(chara)
     end
 end
 
+function actor:onTextSound()
+    Assets.stopAndPlaySound("voice/ceroba")
+    return true
+end
+
 return actor

--- a/data/actors/ceroba_lw.lua
+++ b/data/actors/ceroba_lw.lua
@@ -102,4 +102,9 @@ function actor:onWorldDraw(chara)
     end
 end
 
+function actor:onTextSound()
+    Assets.stopAndPlaySound("voice/ceroba")
+    return true
+end
+
 return actor


### PR DESCRIPTION
Turns out UTY stops voice blips before playing new ones. That's why her voice sounded off in DPR this entire time