### PR TITLE
Fix Game continuing to load after DLC switch has been started

### DIFF
--- a/src/engine/game/game.lua
+++ b/src/engine/game/game.lua
@@ -114,7 +114,7 @@ function Game:enter(previous_state, save_id, save_name, fade)
         save_name = nil
         self:load(save, save_id, fade)
     elseif save_id then
-        Kristal.loadGame(save_id, fade)
+        if not Kristal.loadGame(save_id, fade) then return end
     else
         self:load(nil, nil, fade)
     end

--- a/src/kristal.lua
+++ b/src/kristal.lua
@@ -2041,6 +2041,7 @@ end
 --- Loads the game from a save file.
 ---@param id?   number  The save file index to load. (Defaults to the currently loaded save index)
 ---@param fade? boolean Whether the game should fade in after loading. (Defaults to `false`)
+---@return boolean valid If false, another DLC started to load. Used to stop Game from loading
 function Kristal.loadGame(id, fade)
     id = id or Game.save_id
     local data = Kristal.getSaveFile(id)
@@ -2049,15 +2050,22 @@ function Kristal.loadGame(id, fade)
         if data.mod == Mod.info.id then
             Game:load(data, id, fade)
         else
+            -- I think we need a better way to load into another DLC
+            -- This happens too late in the loading process
+            -- Because we don't switch before, we end up having to restart the whole process in the right DLC
             Kristal.setState({})
             Kristal.clearModState()
+            -- This function is async, which means we have to stop Game from loading itself
+            -- Otherwise it keeps loading without actually having data
             Kristal.loadAssets("", "mods", "", function()
                 Kristal.startGameDPR(id, data.name)
             end)
+            return false
         end
     else
         Game:load(nil, id, fade)
     end
+    return true
 end
 
 --- Returns the data from the specified save file.


### PR DESCRIPTION
Not really a great fix. It should work for now but the main issue is that Dark Place detects whether the game is in the right DLC or not too late By the time it realizes, it has already loaded the wrong DLC and started the Game state so it needs to wipe out everything and restart

The "Game.playtime is nil" crash came from the fact Game kept loading without any save data, because `Kristal.loadGame(id, fade)` didn't actually load anything, wiped everything and called `Kristal.loadAssets()` instead, which is async and start a new Game state This commit makes `Kristal.loadGame()` returns a bool to tell Game to stop itself from loading any further